### PR TITLE
Add support for node kinds (hast, xast)

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,9 +17,11 @@ var green = ansiColor(32, 39)
 // Define ANSII color removal functionality.
 var colorExpression = /(?:(?:\u001B\[)|\u009B)(?:\d{1,3})?(?:(?:;\d{0,3})*)?[A-M|f-m]|\u001B[A-M]/g
 
-// Standard keys defined by unist: https://github.com/syntax-tree/unist.
+// Standard keys defined by unist (<https://github.com/syntax-tree/unist>) that
+// we format differently.
 // We don’t ignore `data` though.
-var ignore = ['type', 'value', 'children', 'position']
+// Also includes `name` (from xast) and `tagName` (from `hast`).
+var ignore = ['type', 'value', 'children', 'position', 'name', 'tagName']
 
 // Inspects a node, without using color.
 function noColor(node) {
@@ -81,11 +83,16 @@ function inspect(node) {
   // Colored node formatter.
   function formatNode(node) {
     var result = [node.type]
+    var kind = node.tagName || node.name
     var position = node.position || {}
     var location = stringifyPosition(position.start, position.end)
     var attributes = []
     var key
     var value
+
+    if (kind) {
+      result.push('<', kind, '>')
+    }
 
     if (node.children) {
       result.push(dim('['), yellow(node.children.length), dim(']'))

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "strip-ansi": "^6.0.0",
     "tape": "^5.0.0",
     "tinyify": "^2.0.0",
+    "xast-util-from-xml": "^1.0.0",
     "xo": "^0.29.0"
   },
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -4,6 +4,7 @@ var test = require('tape')
 var chalk = require('chalk')
 var strip = require('strip-ansi')
 var retext = require('retext')
+var fromXml = require('xast-util-from-xml')
 var inspect = require('.')
 
 var chalkEnabled = new chalk.Instance({level: 1})
@@ -167,7 +168,7 @@ test('inspect()', function (t) {
         children: []
       })
     ),
-    'element[0] [tagName="br"]',
+    'element<br>[0]',
     'should work on parent nodes without children'
   )
 
@@ -181,6 +182,15 @@ test('inspect()', function (t) {
     strip(inspect({type: 'thematicBreak'})),
     'thematicBreak',
     'should work on void nodes'
+  )
+
+  t.equal(
+    strip(inspect(fromXml('<album id="123" />'))),
+    [
+      'root[1]',
+      '└─ element<album>[0] (1:1-1:19, 0-18) [attributes={"id":"123"}]'
+    ].join('\n'),
+    'should work nodes of a certain kind (xast, hast)'
   )
 
   t.equal(


### PR DESCRIPTION
hast and xast are a bit much to look at: every element has a name (xast) or tagName (hast). This makes that cleaner.

Instead of:

```
element[0] [tagName="br"]
```

You now get:

```
element<br>[0]
```

The angle brackets are in part inspired by their use in XML, but also sometimes used by Node’s `util.inspect`:

```
<ref *1> {
  a: [ [Circular *1] ],
  b: <ref *2> { inner: [Circular *2], obj: [Circular *1] }
}
```