### PR TITLE
Change to better show non-unist fields

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-var isEmpty = require('is-empty')
 var color = require('./color')
 
 module.exports = color ? inspect : /* istanbul ignore next */ noColor
@@ -10,6 +9,7 @@ noColor.color = inspect
 inspect.noColor = noColor
 noColor.noColor = noColor
 
+var bold = ansiColor(1, 22)
 var dim = ansiColor(2, 22)
 var yellow = ansiColor(33, 39)
 var green = ansiColor(32, 39)
@@ -21,6 +21,8 @@ var colorExpression = /(?:(?:\u001B\[)|\u009B)(?:\d{1,3})?(?:(?:;\d{0,3})*)?[A-M
 // We don’t ignore `data` though.
 var ignore = ['type', 'value', 'children', 'position']
 
+var dataOnly = ['data', 'attributes', 'properties']
+
 // Inspects a node, without using color.
 function noColor(node) {
   return stripColor(inspect(node))
@@ -28,96 +30,128 @@ function noColor(node) {
 
 // Inspects a node.
 function inspect(node) {
-  return inspectValue(node, '')
+  return inspectValue(node)
 
-  function inspectValue(node, pad) {
+  function inspectValue(node) {
     if (node && Boolean(node.length) && typeof node === 'object') {
-      return inspectAll(node, pad)
+      return inspectNodes(node)
     }
 
     if (node && node.type) {
-      return inspectTree(node, pad)
+      return inspectTree(node)
     }
 
-    return inspectNonTree(node, pad)
+    return inspectNonTree(node)
   }
 
-  function inspectNonTree(value, pad) {
-    return formatNesting(pad) + String(value)
+  function inspectNonTree(value) {
+    return JSON.stringify(value)
   }
 
-  function inspectAll(nodes, pad) {
+  function inspectNodes(nodes) {
     var length = nodes.length
     var index = -1
     var result = []
     var node
     var tail
+    var value
 
     while (++index < length) {
       node = nodes[index]
       tail = index === length - 1
 
+      value =
+        dim((tail ? '└' : '├') + '─' + index) +
+        ' ' +
+        indent(inspectValue(node), (tail ? ' ' : dim('│')) + '   ', true)
+
+      result.push(value)
+    }
+
+    return result.join('\n')
+  }
+
+  function inspectFields(object) {
+    var nonEmpty = object.children && object.children.length
+    var result = []
+    var key
+    var value
+    var formatted
+
+    for (key in object) {
+      value = object[key]
+
+      if (value === undefined || ignore.indexOf(key) !== -1) {
+        continue
+      }
+
+      if (
+        value &&
+        typeof value === 'object' &&
+        typeof value.type === 'string' &&
+        dataOnly.indexOf(key) === -1
+      ) {
+        formatted = inspectTree(value)
+      } else if (
+        Array.isArray(value) &&
+        value[0] &&
+        typeof value[0] === 'object' &&
+        typeof value[0].type === 'string'
+      ) {
+        formatted = '\n' + inspectNodes(value)
+      } else {
+        formatted = inspectNonTree(value)
+      }
+
       result.push(
-        formatNesting(pad + (tail ? '└' : '├') + '─ '),
-        inspectValue(node, pad + (tail ? ' ' : '│') + '  '),
-        tail ? '' : '\n'
+        key + dim(':') + (/\s/.test(formatted.charAt(0)) ? '' : ' ') + formatted
       )
     }
 
-    return result.join('')
+    return indent(result.join('\n'), (nonEmpty ? dim('│') : ' ') + ' ')
   }
 
   function inspectTree(node, pad) {
-    var result = formatNode(node, pad)
-    var content = inspectAll(node.children || [], pad)
-    return content ? result + '\n' + content : result
-  }
-
-  // Colored nesting formatter.
-  function formatNesting(value) {
-    return value ? dim(value) : ''
+    var result = [formatNode(node, pad)]
+    var fields = inspectFields(node)
+    var content = inspectNodes(node.children || [])
+    if (fields) result.push(fields)
+    if (content) result.push(content)
+    return result.join('\n')
   }
 
   // Colored node formatter.
   function formatNode(node) {
-    var result = [node.type]
+    var result = [bold(node.type)]
     var position = node.position || {}
     var location = stringifyPosition(position.start, position.end)
-    var attributes = []
-    var key
-    var value
 
     if (node.children) {
       result.push(dim('['), yellow(node.children.length), dim(']'))
     } else if (typeof node.value === 'string') {
-      result.push(dim(': '), green(JSON.stringify(node.value)))
+      result.push(' ', green(inspectNonTree(node.value, '')))
     }
 
     if (location) {
-      result.push(' (', location, ')')
-    }
-
-    for (key in node) {
-      value = node[key]
-
-      if (
-        ignore.indexOf(key) !== -1 ||
-        value === null ||
-        value === undefined ||
-        (typeof value === 'object' && isEmpty(value))
-      ) {
-        continue
-      }
-
-      attributes.push('[' + key + '=' + JSON.stringify(value) + ']')
-    }
-
-    if (attributes.length !== 0) {
-      result = result.concat(' ', attributes)
+      result.push(' ', dim('('), location, dim(')'))
     }
 
     return result.join('')
   }
+}
+
+function indent(value, indentation, ignoreFirst) {
+  var lines = value.split('\n')
+  var index = ignoreFirst ? 0 : -1
+  var length = lines.length
+
+  if (value === '') return ''
+
+  while (++index < length) {
+    lines[index] = indentation + lines[index]
+  }
+
+  return lines.join('\n')
 }
 
 // Compile a position.

--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ var colorExpression = /(?:(?:\u001B\[)|\u009B)(?:\d{1,3})?(?:(?:;\d{0,3})*)?[A-M
 // we format differently.
 // We don’t ignore `data` though.
 // Also includes `name` (from xast) and `tagName` (from `hast`).
-var ignore = ['type', 'value', 'children', 'position', 'name', 'tagName']
+var ignore = ['type', 'value', 'children', 'position']
+var ignoreString = ['name', 'tagName']
 
 var dataOnly = ['data', 'attributes', 'properties']
 
@@ -90,7 +91,11 @@ function inspect(node, options) {
     for (key in object) {
       value = object[key]
 
-      if (value === undefined || ignore.indexOf(key) !== -1) {
+      if (
+        value === undefined ||
+        ignore.indexOf(key) !== -1 ||
+        (ignoreString.indexOf(key) !== -1 && typeof value === 'string')
+      ) {
         continue
       }
 
@@ -137,9 +142,8 @@ function inspect(node, options) {
     var location = showPositions
       ? stringifyPosition(position.start, position.end)
       : ''
-    var location = stringifyPosition(position.start, position.end)
 
-    if (kind) {
+    if (typeof kind === 'string') {
       result.push('<', kind, '>')
     }
 

--- a/package.json
+++ b/package.json
@@ -36,14 +36,13 @@
     "./color.js": "./color-browser.js"
   },
   "types": "types/index.d.ts",
-  "dependencies": {
-    "is-empty": "^1.0.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/unist": "^2.0.3",
     "browserify": "^16.0.0",
     "chalk": "^4.0.0",
     "dtslint": "^3.0.0",
+    "hastscript": "^5.0.0",
     "nyc": "^15.0.0",
     "prettier": "^2.0.0",
     "remark-cli": "^8.0.0",
@@ -52,6 +51,8 @@
     "strip-ansi": "^6.0.0",
     "tape": "^5.0.0",
     "tinyify": "^2.0.0",
+    "unist-builder": "^2.0.0",
+    "xastscript": "^1.0.0",
     "xo": "^0.29.0"
   },
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -40,11 +40,13 @@ Yields:
 
 ```text
 root[2]
-├─ literal: "1"
-└─ parent[3]
-   ├─ void [id="a"]
-   ├─ literal: "2"
-   └─ node[0] [id="b"]
+├─0 literal "1"
+└─1 parent[3]
+    ├─0 void
+    │     id: "a"
+    ├─1 literal "2"
+    └─2 node[0]
+          id: "b"
 ```
 
 ## API

--- a/test.js
+++ b/test.js
@@ -173,10 +173,7 @@ test('inspect()', function (t) {
   )
   t.equal(
     strip(inspect(x('album', {type: 'vinyl', id: '123'}))),
-    [
-      'element<album>[0]',
-      '  attributes: {"type":"vinyl","id":"123"}'
-    ].join('\n'),
+    'element<album>[0]\n  attributes: {"type":"vinyl","id":"123"}',
     'should see attributes as data'
   )
   t.equal(
@@ -263,7 +260,8 @@ test('inspect()', function (t) {
     strip(inspect(fromXml('<album id="123" />'))),
     [
       'root[1]',
-      '└─ element<album>[0] (1:1-1:19, 0-18) [attributes={"id":"123"}]'
+      '└─0 element<album>[0] (1:1-1:19, 0-18)',
+      '      attributes: {"id":"123"}'
     ].join('\n'),
     'should work nodes of a certain kind (xast, hast)'
   )
@@ -314,27 +312,27 @@ test('inspect()', function (t) {
     strip(inspect(retext().parse(paragraph), {showPositions: false})),
     [
       'RootNode[1]',
-      '└─ ParagraphNode[3]',
-      '   ├─ SentenceNode[6]',
-      '   │  ├─ WordNode[1]',
-      '   │  │  └─ TextNode: "Some"',
-      '   │  ├─ WhiteSpaceNode: " "',
-      '   │  ├─ WordNode[1]',
-      '   │  │  └─ TextNode: "simple"',
-      '   │  ├─ WhiteSpaceNode: " "',
-      '   │  ├─ WordNode[1]',
-      '   │  │  └─ TextNode: "text"',
-      '   │  └─ PunctuationNode: "."',
-      '   ├─ WhiteSpaceNode: " "',
-      '   └─ SentenceNode[6]',
-      '      ├─ WordNode[1]',
-      '      │  └─ TextNode: "Other"',
-      '      ├─ WhiteSpaceNode: " "',
-      '      ├─ PunctuationNode: "“"',
-      '      ├─ WordNode[1]',
-      '      │  └─ TextNode: "sentence"',
-      '      ├─ PunctuationNode: "”"',
-      '      └─ PunctuationNode: "."'
+      '└─0 ParagraphNode[3]',
+      '    ├─0 SentenceNode[6]',
+      '    │   ├─0 WordNode[1]',
+      '    │   │   └─0 TextNode "Some"',
+      '    │   ├─1 WhiteSpaceNode " "',
+      '    │   ├─2 WordNode[1]',
+      '    │   │   └─0 TextNode "simple"',
+      '    │   ├─3 WhiteSpaceNode " "',
+      '    │   ├─4 WordNode[1]',
+      '    │   │   └─0 TextNode "text"',
+      '    │   └─5 PunctuationNode "."',
+      '    ├─1 WhiteSpaceNode " "',
+      '    └─2 SentenceNode[6]',
+      '        ├─0 WordNode[1]',
+      '        │   └─0 TextNode "Other"',
+      '        ├─1 WhiteSpaceNode " "',
+      '        ├─2 PunctuationNode "“"',
+      '        ├─3 WordNode[1]',
+      '        │   └─0 TextNode "sentence"',
+      '        ├─4 PunctuationNode "”"',
+      '        └─5 PunctuationNode "."'
     ].join('\n'),
     'should support `showPositions: false`'
   )

--- a/test.js
+++ b/test.js
@@ -3,6 +3,9 @@
 var test = require('tape')
 var chalk = require('chalk')
 var strip = require('strip-ansi')
+var u = require('unist-builder')
+var h = require('hastscript')
+var x = require('xastscript')
 var retext = require('retext')
 var inspect = require('.')
 
@@ -31,66 +34,41 @@ test('inspect()', function (t) {
     strip(inspect(retext().parse(paragraph))),
     [
       'RootNode[1] (1:1-1:36, 0-35)',
-      '└─ ParagraphNode[3] (1:1-1:36, 0-35)',
-      '   ├─ SentenceNode[6] (1:1-1:18, 0-17)',
-      '   │  ├─ WordNode[1] (1:1-1:5, 0-4)',
-      '   │  │  └─ TextNode: "Some" (1:1-1:5, 0-4)',
-      '   │  ├─ WhiteSpaceNode: " " (1:5-1:6, 4-5)',
-      '   │  ├─ WordNode[1] (1:6-1:12, 5-11)',
-      '   │  │  └─ TextNode: "simple" (1:6-1:12, 5-11)',
-      '   │  ├─ WhiteSpaceNode: " " (1:12-1:13, 11-12)',
-      '   │  ├─ WordNode[1] (1:13-1:17, 12-16)',
-      '   │  │  └─ TextNode: "text" (1:13-1:17, 12-16)',
-      '   │  └─ PunctuationNode: "." (1:17-1:18, 16-17)',
-      '   ├─ WhiteSpaceNode: " " (1:18-1:19, 17-18)',
-      '   └─ SentenceNode[6] (1:19-1:36, 18-35)',
-      '      ├─ WordNode[1] (1:19-1:24, 18-23)',
-      '      │  └─ TextNode: "Other" (1:19-1:24, 18-23)',
-      '      ├─ WhiteSpaceNode: " " (1:24-1:25, 23-24)',
-      '      ├─ PunctuationNode: "“" (1:25-1:26, 24-25)',
-      '      ├─ WordNode[1] (1:26-1:34, 25-33)',
-      '      │  └─ TextNode: "sentence" (1:26-1:34, 25-33)',
-      '      ├─ PunctuationNode: "”" (1:34-1:35, 33-34)',
-      '      └─ PunctuationNode: "." (1:35-1:36, 34-35)'
+      '└─0 ParagraphNode[3] (1:1-1:36, 0-35)',
+      '    ├─0 SentenceNode[6] (1:1-1:18, 0-17)',
+      '    │   ├─0 WordNode[1] (1:1-1:5, 0-4)',
+      '    │   │   └─0 TextNode "Some" (1:1-1:5, 0-4)',
+      '    │   ├─1 WhiteSpaceNode " " (1:5-1:6, 4-5)',
+      '    │   ├─2 WordNode[1] (1:6-1:12, 5-11)',
+      '    │   │   └─0 TextNode "simple" (1:6-1:12, 5-11)',
+      '    │   ├─3 WhiteSpaceNode " " (1:12-1:13, 11-12)',
+      '    │   ├─4 WordNode[1] (1:13-1:17, 12-16)',
+      '    │   │   └─0 TextNode "text" (1:13-1:17, 12-16)',
+      '    │   └─5 PunctuationNode "." (1:17-1:18, 16-17)',
+      '    ├─1 WhiteSpaceNode " " (1:18-1:19, 17-18)',
+      '    └─2 SentenceNode[6] (1:19-1:36, 18-35)',
+      '        ├─0 WordNode[1] (1:19-1:24, 18-23)',
+      '        │   └─0 TextNode "Other" (1:19-1:24, 18-23)',
+      '        ├─1 WhiteSpaceNode " " (1:24-1:25, 23-24)',
+      '        ├─2 PunctuationNode "“" (1:25-1:26, 24-25)',
+      '        ├─3 WordNode[1] (1:26-1:34, 25-33)',
+      '        │   └─0 TextNode "sentence" (1:26-1:34, 25-33)',
+      '        ├─4 PunctuationNode "”" (1:34-1:35, 33-34)',
+      '        └─5 PunctuationNode "." (1:35-1:36, 34-35)'
     ].join('\n'),
     'should work on `RootNode`'
   )
 
   t.equal(
-    strip(inspect(retext().parse(paragraph).children[0].children[0])),
-    [
-      'SentenceNode[6] (1:1-1:18, 0-17)',
-      '├─ WordNode[1] (1:1-1:5, 0-4)',
-      '│  └─ TextNode: "Some" (1:1-1:5, 0-4)',
-      '├─ WhiteSpaceNode: " " (1:5-1:6, 4-5)',
-      '├─ WordNode[1] (1:6-1:12, 5-11)',
-      '│  └─ TextNode: "simple" (1:6-1:12, 5-11)',
-      '├─ WhiteSpaceNode: " " (1:12-1:13, 11-12)',
-      '├─ WordNode[1] (1:13-1:17, 12-16)',
-      '│  └─ TextNode: "text" (1:13-1:17, 12-16)',
-      '└─ PunctuationNode: "." (1:17-1:18, 16-17)'
-    ].join('\n'),
-    'should work on `SentenceNode`'
-  )
-
-  t.equal(
-    strip(
-      inspect([
-        {type: 'SymbolNode', value: '$'},
-        {
-          type: 'WordNode',
-          children: [{type: 'text', value: '5,00'}]
-        }
-      ])
-    ),
-    ['├─ SymbolNode: "$"', '└─ WordNode[1]', '   └─ text: "5,00"'].join('\n'),
+    strip(inspect([u('SymbolNode', '$'), u('WordNode', [u('text', '5,00')])])),
+    '├─0 SymbolNode "$"\n└─1 WordNode[1]\n    └─0 text "5,00"',
     'should work with a list of nodes'
   )
 
   t.test('should work on non-nodes', function (st) {
-    st.equal(strip(inspect('foo')), 'foo')
-    st.equal(strip(inspect('null')), 'null')
-    st.equal(strip(inspect(NaN)), 'NaN')
+    st.equal(strip(inspect('foo')), '"foo"')
+    st.equal(strip(inspect(null)), 'null')
+    st.equal(strip(inspect(NaN)), 'null')
     st.equal(strip(inspect(3)), '3')
 
     st.end()
@@ -104,7 +82,7 @@ test('inspect()', function (t) {
         data: {test: true}
       })
     ),
-    'SymbolNode: "$" [data={"test":true}]',
+    'SymbolNode "$"\n  data: {"test":true}',
     'should work with data attributes'
   )
 
@@ -144,17 +122,18 @@ test('inspect()', function (t) {
       })
     ),
     [
-      'table[2] [align=["left","center"]]',
-      '├─ tableRow[2]',
-      '│  ├─ tableCell[1]',
-      '│  │  └─ text: "foo"',
-      '│  └─ tableCell[1]',
-      '│     └─ text: "bar"',
-      '└─ tableRow[2]',
-      '   ├─ tableCell[1]',
-      '   │  └─ text: "baz"',
-      '   └─ tableCell[1]',
-      '      └─ text: "qux"'
+      'table[2]',
+      '│ align: ["left","center"]',
+      '├─0 tableRow[2]',
+      '│   ├─0 tableCell[1]',
+      '│   │   └─0 text "foo"',
+      '│   └─1 tableCell[1]',
+      '│       └─0 text "bar"',
+      '└─1 tableRow[2]',
+      '    ├─0 tableCell[1]',
+      '    │   └─0 text "baz"',
+      '    └─1 tableCell[1]',
+      '        └─0 text "qux"'
     ].join('\n'),
     'should work with other attributes'
   )
@@ -167,13 +146,13 @@ test('inspect()', function (t) {
         children: []
       })
     ),
-    'element[0] [tagName="br"]',
+    'element[0]\n  tagName: "br"',
     'should work on parent nodes without children'
   )
 
   t.equal(
     strip(inspect({type: 'text', value: ''})),
-    'text: ""',
+    'text ""',
     'should work on text nodes without value'
   )
 
@@ -181,6 +160,104 @@ test('inspect()', function (t) {
     strip(inspect({type: 'thematicBreak'})),
     'thematicBreak',
     'should work on void nodes'
+  )
+
+  t.equal(
+    strip(inspect(h('button', {type: 'submit', value: 'Send'}))),
+    [
+      'element[0]',
+      '  tagName: "button"',
+      '  properties: {"type":"submit","value":"Send"}'
+    ].join('\n'),
+    'should see properties as data'
+  )
+  t.equal(
+    strip(inspect(x('album', {type: 'vinyl', id: '123'}))),
+    [
+      'element[0]',
+      '  name: "album"',
+      '  attributes: {"type":"vinyl","id":"123"}'
+    ].join('\n'),
+    'should see attributes as data'
+  )
+  t.equal(
+    strip(inspect({type: 'node', data: {type: 'notNode'}})),
+    'node\n  data: {"type":"notNode"}',
+    'should see data as data'
+  )
+  t.equal(
+    strip(
+      inspect(
+        u(
+          'jsxSpan',
+          {
+            open: u('jsxTag', {
+              close: false,
+              selfClosing: false,
+              name: u('jsxMember', {
+                object: u('jsxMember', {
+                  object: u('jsxIdentifier', 'abc'),
+                  property: u('jsxIdentifier', 'def')
+                }),
+                property: u('jsxIdentifier', 'ghi')
+              }),
+              attributes: [
+                u('jsxAttribute', {
+                  name: u('jsxIdentifier', 'alpha'),
+                  value: null
+                }),
+                u('jsxAttributeExpression', '...props'),
+                u('jsxAttribute', {
+                  name: u('jsxIdentifier', 'bravo'),
+                  value: null
+                })
+              ]
+            }),
+            close: u('jsxTag', {
+              close: true,
+              selfClosing: false,
+              name: u('jsxMember', {
+                object: u('jsxMember', {
+                  object: u('jsxIdentifier', 'abc'),
+                  property: u('jsxIdentifier', 'def')
+                }),
+                property: u('jsxIdentifier', 'ghi')
+              }),
+              attributes: []
+            })
+          },
+          [u('jsxExpressionSpan', '1 + 1')]
+        )
+      )
+    ),
+    [
+      'jsxSpan[1]',
+      '│ open: jsxTag',
+      '│   close: false',
+      '│   selfClosing: false',
+      '│   name: jsxMember',
+      '│     object: jsxMember',
+      '│       object: jsxIdentifier "abc"',
+      '│       property: jsxIdentifier "def"',
+      '│     property: jsxIdentifier "ghi"',
+      '│   attributes:',
+      '│   ├─0 jsxAttribute',
+      '│   │     name: jsxIdentifier "alpha"',
+      '│   ├─1 jsxAttributeExpression "...props"',
+      '│   └─2 jsxAttribute',
+      '│         name: jsxIdentifier "bravo"',
+      '│ close: jsxTag',
+      '│   close: true',
+      '│   selfClosing: false',
+      '│   name: jsxMember',
+      '│     object: jsxMember',
+      '│       object: jsxIdentifier "abc"',
+      '│       property: jsxIdentifier "def"',
+      '│     property: jsxIdentifier "ghi"',
+      '│   attributes: []',
+      '└─0 jsxExpressionSpan "1 + 1"'
+    ].join('\n'),
+    'should handle nodes outside of children'
   )
 
   t.equal(
@@ -194,7 +271,7 @@ test('inspect()', function (t) {
         }
       })
     ),
-    'foo: "foo\\nbaar" (1:1-2:5)',
+    'foo "foo\\nbaar" (1:1-2:5)',
     'should work without `offset` in `position`'
   )
 
@@ -206,7 +283,7 @@ test('inspect()', function (t) {
         position: {start: {}, end: {}}
       })
     ),
-    'foo: "foo\\nbaar" (1:1-1:1)',
+    'foo "foo\\nbaar" (1:1-1:1)',
     'should work without `line` and `column` in `position`'
   )
 
@@ -221,7 +298,7 @@ test('inspect()', function (t) {
         }
       })
     ),
-    'foo: "foo\\nbaar" (1:1-1:1, 1-8)',
+    'foo "foo\\nbaar" (1:1-1:1, 1-8)',
     'should work with just `offset` in `position`'
   )
 
@@ -233,15 +310,15 @@ test('inspect.noColor()', function (t) {
     inspect.noColor(retext().parse(paragraph).children[0].children[0]),
     [
       'SentenceNode[6] (1:1-1:18, 0-17)',
-      '├─ WordNode[1] (1:1-1:5, 0-4)',
-      '│  └─ TextNode: "Some" (1:1-1:5, 0-4)',
-      '├─ WhiteSpaceNode: " " (1:5-1:6, 4-5)',
-      '├─ WordNode[1] (1:6-1:12, 5-11)',
-      '│  └─ TextNode: "simple" (1:6-1:12, 5-11)',
-      '├─ WhiteSpaceNode: " " (1:12-1:13, 11-12)',
-      '├─ WordNode[1] (1:13-1:17, 12-16)',
-      '│  └─ TextNode: "text" (1:13-1:17, 12-16)',
-      '└─ PunctuationNode: "." (1:17-1:18, 16-17)'
+      '├─0 WordNode[1] (1:1-1:5, 0-4)',
+      '│   └─0 TextNode "Some" (1:1-1:5, 0-4)',
+      '├─1 WhiteSpaceNode " " (1:5-1:6, 4-5)',
+      '├─2 WordNode[1] (1:6-1:12, 5-11)',
+      '│   └─0 TextNode "simple" (1:6-1:12, 5-11)',
+      '├─3 WhiteSpaceNode " " (1:12-1:13, 11-12)',
+      '├─4 WordNode[1] (1:13-1:17, 12-16)',
+      '│   └─0 TextNode "text" (1:13-1:17, 12-16)',
+      '└─5 PunctuationNode "." (1:17-1:18, 16-17)'
     ].join('\n'),
     'should work'
   )
@@ -253,59 +330,104 @@ test('inspect.color()', function (t) {
   t.equal(
     inspect.color(retext().parse(paragraph).children[0].children[0]),
     [
-      'SentenceNode' +
+      chalkEnabled.bold('SentenceNode') +
         chalkEnabled.dim('[') +
         chalkEnabled.yellow('6') +
         chalkEnabled.dim(']') +
-        ' (1:1-1:18, 0-17)',
-      chalkEnabled.dim('├─ ') +
-        'WordNode' +
+        ' ' +
+        chalkEnabled.dim('(') +
+        '1:1-1:18, 0-17' +
+        chalkEnabled.dim(')'),
+      chalkEnabled.dim('├─0') +
+        ' ' +
+        chalkEnabled.bold('WordNode') +
         chalkEnabled.dim('[') +
         chalkEnabled.yellow('1') +
         chalkEnabled.dim(']') +
-        ' (1:1-1:5, 0-4)',
-      chalkEnabled.dim('│  └─ ') +
-        'TextNode' +
-        chalkEnabled.dim(': ') +
+        ' ' +
+        chalkEnabled.dim('(') +
+        '1:1-1:5, 0-4' +
+        chalkEnabled.dim(')'),
+      chalkEnabled.dim('│') +
+        '   ' +
+        chalkEnabled.dim('└─0') +
+        ' ' +
+        chalkEnabled.bold('TextNode') +
+        ' ' +
         chalkEnabled.green('"Some"') +
-        ' (1:1-1:5, 0-4)',
-      chalkEnabled.dim('├─ ') +
-        'WhiteSpaceNode' +
-        chalkEnabled.dim(': ') +
+        ' ' +
+        chalkEnabled.dim('(') +
+        '1:1-1:5, 0-4' +
+        chalkEnabled.dim(')'),
+      chalkEnabled.dim('├─1') +
+        ' ' +
+        chalkEnabled.bold('WhiteSpaceNode') +
+        ' ' +
         chalkEnabled.green('" "') +
-        ' (1:5-1:6, 4-5)',
-      chalkEnabled.dim('├─ ') +
-        'WordNode' +
+        ' ' +
+        chalkEnabled.dim('(') +
+        '1:5-1:6, 4-5' +
+        chalkEnabled.dim(')'),
+      chalkEnabled.dim('├─2') +
+        ' ' +
+        chalkEnabled.bold('WordNode') +
         chalkEnabled.dim('[') +
         chalkEnabled.yellow('1') +
         chalkEnabled.dim(']') +
-        ' (1:6-1:12, 5-11)',
-      chalkEnabled.dim('│  └─ ') +
-        'TextNode' +
-        chalkEnabled.dim(': ') +
+        ' ' +
+        chalkEnabled.dim('(') +
+        '1:6-1:12, 5-11' +
+        chalkEnabled.dim(')'),
+      chalkEnabled.dim('│') +
+        '   ' +
+        chalkEnabled.dim('└─0') +
+        ' ' +
+        chalkEnabled.bold('TextNode') +
+        ' ' +
         chalkEnabled.green('"simple"') +
-        ' (1:6-1:12, 5-11)',
-      chalkEnabled.dim('├─ ') +
-        'WhiteSpaceNode' +
-        chalkEnabled.dim(': ') +
+        ' ' +
+        chalkEnabled.dim('(') +
+        '1:6-1:12, 5-11' +
+        chalkEnabled.dim(')'),
+      chalkEnabled.dim('├─3') +
+        ' ' +
+        chalkEnabled.bold('WhiteSpaceNode') +
+        ' ' +
         chalkEnabled.green('" "') +
-        ' (1:12-1:13, 11-12)',
-      chalkEnabled.dim('├─ ') +
-        'WordNode' +
+        ' ' +
+        chalkEnabled.dim('(') +
+        '1:12-1:13, 11-12' +
+        chalkEnabled.dim(')'),
+      chalkEnabled.dim('├─4') +
+        ' ' +
+        chalkEnabled.bold('WordNode') +
         chalkEnabled.dim('[') +
         chalkEnabled.yellow('1') +
         chalkEnabled.dim(']') +
-        ' (1:13-1:17, 12-16)',
-      chalkEnabled.dim('│  └─ ') +
-        'TextNode' +
-        chalkEnabled.dim(': ') +
+        ' ' +
+        chalkEnabled.dim('(') +
+        '1:13-1:17, 12-16' +
+        chalkEnabled.dim(')'),
+      chalkEnabled.dim('│') +
+        '   ' +
+        chalkEnabled.dim('└─0') +
+        ' ' +
+        chalkEnabled.bold('TextNode') +
+        ' ' +
         chalkEnabled.green('"text"') +
-        ' (1:13-1:17, 12-16)',
-      chalkEnabled.dim('└─ ') +
-        'PunctuationNode' +
-        chalkEnabled.dim(': ') +
+        ' ' +
+        chalkEnabled.dim('(') +
+        '1:13-1:17, 12-16' +
+        chalkEnabled.dim(')'),
+      chalkEnabled.dim('└─5') +
+        ' ' +
+        chalkEnabled.bold('PunctuationNode') +
+        ' ' +
         chalkEnabled.green('"."') +
-        ' (1:17-1:18, 16-17)'
+        ' ' +
+        chalkEnabled.dim('(') +
+        '1:17-1:18, 16-17' +
+        chalkEnabled.dim(')')
     ].join('\n'),
     'should work'
   )


### PR DESCRIPTION
Previously, all fields that were not specified by unist, but for example
defined in another spec such as hast, were show rather verbosely on one line.

This especially became unreadable when those fields were populated with a single
node, or a list of nodes.

This change makes fields more readable, by displaying them on their own line,
and supports nodes or list of nodes as the values of those fields.
It also streamlines the indentation a bit: previously, 3 spaces were used: now,
either 2 or 4 spaces.
Finally, there is now a number before each child, which shows its index.

Closes GH-11.
