### PR TITLE
Fix typo to expose `Options` type

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('./lib/index.js')} Options
+ * @typedef {import('./lib/index.js').Options} Options
  *
  * @typedef {Options} InspectOptions
  *   Deprecated, use `Options`.


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

The type of `Options` was exported as the type of the `lib/index.js` module itself, not the intended `Options` type.

This fixes that export.

<!--do not edit: pr-->
