### PR TITLE
Refactor to use import map

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@
  *   Whether to include positional information.
  */
 
-import {color} from 'unist-util-inspect/do-not-use-conditional-color'
+import {color} from '#conditional-color'
 
 /**
  * Inspect a node, with color in Node, without color in browsers.

--- a/package.json
+++ b/package.json
@@ -26,8 +26,10 @@
   "sideEffects": false,
   "type": "module",
   "exports": {
-    ".": "./index.js",
-    "./do-not-use-conditional-color": {
+    ".": "./index.js"
+  },
+  "imports": {
+    "#conditional-color": {
       "node": "./lib/color.node.js",
       "default": "./lib/color.default.js"
     }


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

The module exported an entrypoint `do-not-use-conditional-color` as a way of using the module system to determine a runtime default value. However, a subpath *import* is more appropriate for this, because they're private and don't introduce a public entrypoint:
https://nodejs.org/api/packages.html#subpath-imports

<!--do not edit: pr-->
