### PR TITLE
Correct type annotation for `inspect` to match README

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@ const emptyOptions = {}
 const own = {}.hasOwnProperty
 
 /**
- * Inspect a node, without color.
+ * Inspect a tree, with color in Node, without color in browsers.
  *
  * @param {unknown} tree
  *   Tree to inspect.

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@ const emptyOptions = {}
 const own = {}.hasOwnProperty
 
 /**
- * Inspect a tree, with color in Node, without color in browsers.
+ * Inspect a tree.
  *
  * @param {unknown} tree
  *   Tree to inspect.

--- a/readme.md
+++ b/readme.md
@@ -98,7 +98,7 @@ There is no default export.
 
 ### `inspect(tree[, options])`
 
-Inspect a tree, with color in Node, without color in browsers.
+Inspect a tree.
 
 ###### Parameters
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Asyntax-tree&type=issues and https://github.com/orgs/syntax-tree/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

The description of the `inspect` function in the type annotation does not match the description in the README and is misleading.

<!--do not edit: pr-->
